### PR TITLE
Add [admin] multi-assessment performance analytics

### DIFF
--- a/assessment-creator/pages/5_[admin].py
+++ b/assessment-creator/pages/5_[admin].py
@@ -1,0 +1,180 @@
+# Assessment performance analytics across a fixed set of assessments (staff only).
+
+import streamlit as st
+import utils_assessment_analysis
+
+ADMIN_ASSESSMENT_IDS = (
+    "e40cedb5-6658-49d5-9de8-fe18c08fa0e9",
+    "2ca0d560-0a85-4525-bf3e-ca17b7b384ee",
+    "3dffaee0-f987-409e-8dc9-86a5e8e34c88",
+    "98d0e7f1-f288-4b82-8092-09b860a0e062",
+    "d662a9b5-c52d-4d8b-9f3f-2a0fc5e9c823",
+    "b8a665ee-8098-4d90-b2dd-4b1fbf9ddaa7",
+    "df89501b-bf2a-46ac-a991-d8e2942906c2",
+    "a2cccf2c-f650-40b3-af23-f8780550c55c",
+    "7a6ea823-704a-422d-b482-2209cceb1192",
+    "d3a8269f-32ab-4795-aab1-c7610132279e",
+    "da24aa70-721a-429d-bb15-48f0d931b1da",
+    "ba879186-7ec6-48b0-950b-6b848db57073",
+    "92b81dee-0980-4f42-adec-85757f02e5a1",
+    "2600fa44-752d-4d8d-afb8-9bbcbf596a92",
+    "af4f0000-a705-432d-88b5-991998ac4a6b",
+    "963a85a4-9927-463e-b7c4-882806a4de05",
+    "df72b3ae-58a5-47e9-b9a7-542ea9094590",
+    "66d36ee7-1b16-4c07-a9a7-9c61f567310d",
+    "901160fa-815f-4d5c-9b77-5da1709a3796",
+    "08ddc21a-b70c-4270-9067-08cbb23e4f1e",
+    "6bdd3732-e5b3-4bf2-befd-b6589f57547d",
+    "6677bc06-2b81-457c-8d6b-1fb8c16b15d9",
+    "d9293201-f36e-4865-ae4c-64557d1c4715",
+    "3765905f-1293-45e0-82cd-26c2d0bd4083",
+    "eb3ecd84-e0f4-4e94-9fdf-3c972abaf4c1",
+    "f3f78593-151a-4702-a1e5-f6fa09860041",
+    "2fcbfefc-06fa-4c56-824c-886297e9c845",
+    "30b11a7d-51e7-498d-9ddd-bfab10e28734",
+    "79e66277-6e43-4cad-bc34-b8ecb1d76041",
+    "fd674195-cc62-4fbe-8dcb-4b1fec7722b7",
+    "e9d43249-f2f8-426a-aece-a35c2ac91b34",
+    "4a1a70a2-26af-4340-aa90-56ad49b0edce",
+    "bac415b4-ae06-406e-8125-23108c8e7597",
+    "91b8d450-1194-4f75-afc1-7dd0ce97ca10",
+    "aa4adf51-4735-4c93-b17f-3aafaa8c2827",
+    "73144685-dce7-4592-857f-dd17567308d3",
+    "aaba1da4-a743-4731-9456-cbc83ff92fd8",
+    "37286ce7-e3fa-4252-9af2-3f3892df6b17",
+    "351a34e3-80d1-4e9c-853e-f1fc33dbe5ef",
+    "bc59bd61-a985-409e-bc3a-d8b2bb3153bb",
+    "dc7673d9-081b-4c38-aefe-7bdeab77d328",
+    "d945c1ba-d740-42ff-bb7b-b3c69105dbab",
+    "004b1220-4393-4267-992f-2ea59a449165",
+    "e280cdb8-96e3-483b-9d68-e0185553a472",
+    "99335d2c-6763-4c82-b7c8-4ef40ea89489",
+    "bfde5145-8527-42f5-9f84-d77eaa7fe2eb",
+    "c1d83f31-53bd-4db6-8539-36ce5797eef4",
+    "06eb9728-d08a-4c3c-95f8-6bfaded2528e",
+    "c61a1eb7-1f8e-4c3a-84f0-3e4c082f93e2",
+    "3488534e-f599-40c7-b5b3-5fc486250c15",
+    "7297d30b-eee1-4416-990e-18e557e208ac",
+    "9daab139-fbca-4c1f-bd9d-fb7ef885add1",
+    "259396bb-1b30-49b9-b729-a9a5470b975a",
+    "f50c0b35-6383-41b6-aeac-45b9553048d8",
+    "a5299f92-4e85-44cc-8cd6-ce67a5114f27",
+    "873956ef-4ce4-4518-b5a8-33b4e6e1f90d",
+    "3bc80325-3026-4a5a-839b-c7efa00cf6ba",
+)
+
+st.set_page_config(
+    page_title="[admin]",
+    page_icon="",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+st.title("[admin]")
+st.caption("Aggregated assessment performance analytics for the configured assessment IDs.")
+
+with st.form("admin_load"):
+    st.markdown("#### Staff password")
+    password = st.text_input(
+        "Staff password",
+        type="password",
+        help="Same staff password as other secured tabs (`password` in Streamlit secrets).",
+        key="admin_password_input",
+    )
+    submitted = st.form_submit_button("Load analytics for all assessments")
+
+if submitted:
+    if password != utils_assessment_analysis.settings.PASSWORD:
+        st.error("Incorrect password.")
+    else:
+        prog = st.progress(0.0, text="Loading assessments…")
+        try:
+            df = utils_assessment_analysis.get_results_multi(
+                ADMIN_ASSESSMENT_IDS,
+                progress_bar=prog,
+            )
+        finally:
+            prog.empty()
+        if df.empty:
+            st.warning("No attempt data returned for any configured assessment ID.")
+            st.session_state.pop("admin_perf_df", None)
+        else:
+            st.session_state["admin_perf_df"] = df
+            loaded_ids = sorted(df["assessmentId"].astype(str).unique())
+            st.success(
+                f"Loaded {len(df):,} rows across {len(loaded_ids)} assessment(s) with data."
+            )
+
+if "admin_perf_df" not in st.session_state:
+    st.stop()
+
+full_df = st.session_state["admin_perf_df"]
+assessment_options = sorted(full_df["assessmentId"].astype(str).unique())
+
+st.sidebar.markdown("### Filters")
+scope = st.sidebar.radio(
+    "Assessments",
+    ["All assessments", "Choose assessments"],
+    horizontal=False,
+)
+if scope == "All assessments":
+    selected_assessments = assessment_options
+else:
+    selected_assessments = st.sidebar.multiselect(
+        "Assessment IDs",
+        options=assessment_options,
+        default=assessment_options,
+    )
+
+assessment_filtered = full_df[full_df["assessmentId"].astype(str).isin(selected_assessments)]
+
+section_titles = (
+    assessment_filtered["sectionTitle"]
+    .dropna()
+    .astype(str)
+    .sort_values()
+    .unique()
+    .tolist()
+)
+
+section_scope = st.sidebar.radio(
+    "Sections",
+    ["All sections", "Choose sections"],
+    horizontal=False,
+)
+
+if not selected_assessments:
+    st.warning("Select at least one assessment.")
+    st.stop()
+
+if section_scope == "All sections":
+    view_df = assessment_filtered
+else:
+    if not section_titles:
+        st.warning("No section titles in the current assessment selection.")
+        st.stop()
+    selected_sections = st.sidebar.multiselect(
+        "Section titles",
+        options=section_titles,
+        default=section_titles,
+    )
+    if not selected_sections:
+        st.warning("Select at least one section.")
+        st.stop()
+    view_df = assessment_filtered[
+        assessment_filtered["sectionTitle"].isin(selected_sections)
+    ]
+
+if view_df.empty:
+    st.warning("No rows match the current filters.")
+    st.stop()
+
+st.info(
+    "**Assessment Performance Analysis** — question quality, score distributions, and section "
+    "performance (same charts as the Analyzing Assessments tab). Adjust filters in the sidebar "
+    "to focus on all configured assessments or a subset, and to limit sections."
+)
+
+utils_assessment_analysis.plot_question_analysis(view_df)
+utils_assessment_analysis.plot_total_score_histogram(view_df)
+utils_assessment_analysis.plot_section_scores(view_df)

--- a/assessment-creator/utils_assessment_analysis.py
+++ b/assessment-creator/utils_assessment_analysis.py
@@ -492,6 +492,51 @@ def get_results(assessment_id):
     df = df.merge(skills_map, how='left', left_on='skillId', right_index=True)
     return df
 
+def _enrich_attempts_df(df, difficulty_map, skills_map, assessment_id):
+    """Merge difficulty/skills maps and tag rows with assessment_id."""
+    if df is None or df.empty:
+        return None
+    out = df.merge(difficulty_map, how='left', left_on='difficultyLevelId', right_index=True)
+    out = out.merge(skills_map, how='left', left_on='skillId', right_index=True)
+    out['assessmentId'] = assessment_id
+    return out
+
+def get_results_multi(assessment_ids, max_workers=8, progress_bar=None):
+    """
+    Fetch attempts for many assessments, merge catalog maps once, concatenate with assessmentId.
+    Failed IDs are skipped (returns partial data).
+    """
+    ids = [str(x).strip() for x in assessment_ids if str(x).strip()]
+    if not ids:
+        return pd.DataFrame()
+
+    difficulty_map = get_difficulty_levels()
+    skills_map = get_skills()
+
+    def load_one(aid):
+        try:
+            raw = get_attempts_dataframe(aid)
+            return _enrich_attempts_df(raw, difficulty_map, skills_map, aid)
+        except Exception:
+            return None
+
+    frames = []
+    total = len(ids)
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_map = {executor.submit(load_one, aid): aid for aid in ids}
+        for fut in concurrent.futures.as_completed(future_map):
+            got = fut.result()
+            if got is not None and not got.empty:
+                frames.append(got)
+            done += 1
+            if progress_bar is not None:
+                progress_bar.progress(min(done / total, 1.0))
+
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
 def user_skills(df):
     # Get a list of unique users.
     user_list = df['userId'].unique()
@@ -840,33 +885,28 @@ def calculate_question_statistics(results_df):
     Difficulty = proportion of students who answered correctly
     Discrimination = correlation between question score and total score
     """
-    # Group by question to calculate statistics
     question_stats = {}
-    
-    for question_id in results_df['questionId'].unique():
-        question_data = results_df[results_df['questionId'] == question_id]
-        
+    has_assessment = (
+        'assessmentId' in results_df.columns
+        and results_df['assessmentId'].notna().any()
+    )
+
+    def stats_for_slice(question_data, dict_key, assessment_id_val=None, question_id_val=None):
         if len(question_data) == 0:
-            continue
-            
-        # Calculate difficulty (proportion correct)
+            return
         difficulty = question_data['questionScore'].mean()
-        
-        # Calculate discrimination (correlation with total score)
-        # Only calculate if we have variation in both question scores and total scores
         if len(question_data) > 1 and question_data['questionScore'].std() > 0 and question_data['totalScore'].std() > 0:
             discrimination = question_data['questionScore'].corr(question_data['totalScore'])
         else:
             discrimination = 0.0
-            
-        # Get additional question info
         skill_title = question_data['skillsTitle'].iloc[0] if 'skillsTitle' in question_data.columns else 'Unknown'
         difficulty_level = question_data['difficultyLabel'].iloc[0] if 'difficultyLabel' in question_data.columns else 'Unknown'
         concept_title = question_data['conceptTitle'].iloc[0] if 'conceptTitle' in question_data.columns else 'Unknown'
         question_content = question_data['questionContent'].iloc[0] if 'questionContent' in question_data.columns else 'No content available'
         question_choices = question_data['questionChoices'].iloc[0] if 'questionChoices' in question_data.columns else '[]'
-        
-        question_stats[question_id] = {
+        qid = question_id_val if question_id_val is not None else dict_key
+        row = {
+            'question_id': qid,
             'difficulty': difficulty,
             'discrimination': discrimination,
             'skill_title': skill_title,
@@ -874,9 +914,23 @@ def calculate_question_statistics(results_df):
             'concept_title': concept_title,
             'question_content': question_content,
             'question_choices': question_choices,
-            'n_attempts': len(question_data)
+            'n_attempts': len(question_data),
         }
-    
+        if assessment_id_val is not None:
+            row['assessment_id'] = assessment_id_val
+        question_stats[dict_key] = row
+
+    if has_assessment:
+        grouped = results_df.dropna(subset=['questionId']).groupby(
+            ['assessmentId', 'questionId'], sort=False
+        )
+        for (aid, qid), question_data in grouped:
+            stats_for_slice(question_data, f"{aid}::{qid}", assessment_id_val=aid, question_id_val=qid)
+    else:
+        for question_id in results_df['questionId'].dropna().unique():
+            question_data = results_df[results_df['questionId'] == question_id]
+            stats_for_slice(question_data, question_id)
+
     return question_stats
 
 def plot_question_analysis(results_df):
@@ -888,10 +942,8 @@ def plot_question_analysis(results_df):
     if not question_stats:
         return
     
-    # Convert to DataFrame for easier plotting
-    stats_df = pd.DataFrame.from_dict(question_stats, orient='index')
-    stats_df['question_id'] = stats_df.index
-    
+    stats_df = pd.DataFrame.from_dict(question_stats, orient='index').reset_index(drop=True)
+
     # Filter out questions with too few attempts or invalid statistics
     stats_df = stats_df[stats_df['n_attempts'] >= 3]  # Minimum 3 attempts
     stats_df = stats_df[stats_df['discrimination'].notna()]  # Valid discrimination values
@@ -973,8 +1025,22 @@ def plot_question_analysis(results_df):
     st.pyplot(fig)
     
     # Add question details table (underlying data for the chart)
-    display_df = stats_df[['question_id', 'difficulty', 'discrimination', 'skill_title', 'difficulty_level', 'n_attempts', 'question_content', 'question_choices']].copy()
-    display_df.columns = ['Question ID', 'Success Rate', 'Discrimination', 'Skill', 'Difficulty Level', 'Attempts', 'Question Content', 'Question Choices']
+    table_cols = ['question_id', 'difficulty', 'discrimination', 'skill_title', 'difficulty_level', 'n_attempts', 'question_content', 'question_choices']
+    if 'assessment_id' in stats_df.columns:
+        table_cols = ['assessment_id'] + table_cols
+    display_df = stats_df[table_cols].copy()
+    rename_map = {
+        'assessment_id': 'Assessment ID',
+        'question_id': 'Question ID',
+        'difficulty': 'Success Rate',
+        'discrimination': 'Discrimination',
+        'skill_title': 'Skill',
+        'difficulty_level': 'Difficulty Level',
+        'n_attempts': 'Attempts',
+        'question_content': 'Question Content',
+        'question_choices': 'Question Choices',
+    }
+    display_df = display_df.rename(columns=rename_map)
     display_df = display_df.sort_values('Discrimination', ascending=False)
     st.caption("Question performance data")
     st.dataframe(display_df, use_container_width=True)


### PR DESCRIPTION
## Summary
Adds a staff-only **[admin]** page that loads a fixed list of assessment IDs in parallel and shows the same **Assessment Performance Analysis** charts as tab 4 (question analysis, total score histogram, section scores).

## Details
- New page: `assessment-creator/pages/5_[admin].py` — password uses existing Streamlit secret `password` (same as other secured tabs).
- New `get_results_multi()` in `utils_assessment_analysis.py`; question stats support multiple assessments via `(assessmentId, questionId)`.
- Sidebar filters: all vs chosen assessments; all vs chosen sections.

Made with [Cursor](https://cursor.com)