### PR TITLE
Admin analytics: assessment-level summary + section charts when single assessment

### DIFF
--- a/assessment-creator/pages/5_[admin].py
+++ b/assessment-creator/pages/5_[admin].py
@@ -1,5 +1,6 @@
 # Assessment performance analytics across a fixed set of assessments (staff only).
 
+import pandas as pd
 import streamlit as st
 import utils_assessment_analysis
 
@@ -169,12 +170,59 @@ if view_df.empty:
     st.warning("No rows match the current filters.")
     st.stop()
 
+single_assessment = len(selected_assessments) == 1
+
 st.info(
-    "**Assessment Performance Analysis** — question quality, score distributions, and section "
-    "performance (same charts as the Analyzing Assessments tab). Adjust filters in the sidebar "
-    "to focus on all configured assessments or a subset, and to limit sections."
+    "**Assessment Performance Analysis** — question quality and total-score distributions "
+    "(same as the Analyzing Assessments tab). **Section performance** charts appear only when "
+    "exactly **one** assessment is selected in the sidebar. Use **Assessment-level summary** "
+    "below to compare assessments using aggregated question metrics."
 )
+
+st.subheader("Assessment-level summary")
+st.caption(
+    "Question-level stats are aggregated per assessment (weighted by response count). Only "
+    "questions with at least three attempts and valid discrimination are included—matching "
+    "the question performance chart. **Attempts** counts distinct assessment attempts in the "
+    "current filter sample."
+)
+summary_df = utils_assessment_analysis.assessment_level_summary_table(view_df)
+if summary_df.empty:
+    st.warning("No assessments in the current filter.")
+else:
+    display_summary = summary_df.copy()
+    display_summary["Avg success rate"] = display_summary["avg_success_rate"].map(
+        lambda x: f"{x:.3f}" if pd.notna(x) else "—"
+    )
+    display_summary["Avg discrimination"] = display_summary["avg_discrimination"].map(
+        lambda x: f"{x:.3f}" if pd.notna(x) else "—"
+    )
+    display_summary = display_summary.rename(
+        columns={
+            "assessment_id": "Assessment ID",
+            "questions_in_summary": "Questions in summary",
+            "n_attempts": "Attempts (distinct)",
+        }
+    )
+    display_summary = display_summary[
+        [
+            "Assessment ID",
+            "Questions in summary",
+            "Avg success rate",
+            "Avg discrimination",
+            "Attempts (distinct)",
+        ]
+    ]
+    st.dataframe(display_summary, use_container_width=True, hide_index=True)
 
 utils_assessment_analysis.plot_question_analysis(view_df)
 utils_assessment_analysis.plot_total_score_histogram(view_df)
-utils_assessment_analysis.plot_section_scores(view_df)
+
+if single_assessment:
+    utils_assessment_analysis.plot_section_scores(view_df)
+else:
+    st.subheader("Section performance")
+    st.info(
+        "Select **exactly one** assessment under **Assessments → Choose assessments** to load "
+        "section-level charts and tables."
+    )

--- a/assessment-creator/utils_assessment_analysis.py
+++ b/assessment-creator/utils_assessment_analysis.py
@@ -933,6 +933,65 @@ def calculate_question_statistics(results_df):
 
     return question_stats
 
+def assessment_level_summary_table(results_df, min_attempts_per_question=3):
+    """
+    Roll up question-level statistics (same eligibility filters as plot_question_analysis)
+    to one row per assessment: weighted avg success rate and discrimination, question count,
+    and distinct attempt count in the sample.
+    """
+    if results_df is None or results_df.empty:
+        return pd.DataFrame()
+
+    if 'assessmentId' not in results_df.columns:
+        return pd.DataFrame()
+
+    question_stats = calculate_question_statistics(results_df)
+    stats_df = (
+        pd.DataFrame.from_dict(question_stats, orient='index').reset_index(drop=True)
+        if question_stats
+        else pd.DataFrame()
+    )
+    if not stats_df.empty:
+        stats_df = stats_df[stats_df['n_attempts'] >= min_attempts_per_question]
+        stats_df = stats_df[stats_df['discrimination'].notna()]
+
+    rows = []
+    for aid in sorted(results_df['assessmentId'].dropna().astype(str).unique()):
+        sub = results_df[results_df['assessmentId'].astype(str) == aid]
+        n_attempts_distinct = int(sub.dropna(subset=['id'])['id'].nunique())
+
+        if stats_df.empty or 'assessment_id' not in stats_df.columns:
+            g = pd.DataFrame()
+        else:
+            g = stats_df[stats_df['assessment_id'].astype(str) == aid]
+
+        if len(g) == 0:
+            rows.append(
+                {
+                    'assessment_id': aid,
+                    'questions_in_summary': 0,
+                    'avg_success_rate': np.nan,
+                    'avg_discrimination': np.nan,
+                    'n_attempts': n_attempts_distinct,
+                }
+            )
+            continue
+
+        w = g['n_attempts'].sum()
+        avg_sr = float((g['difficulty'] * g['n_attempts']).sum() / w) if w else np.nan
+        avg_disc = float((g['discrimination'] * g['n_attempts']).sum() / w) if w else np.nan
+        rows.append(
+            {
+                'assessment_id': aid,
+                'questions_in_summary': int(len(g)),
+                'avg_success_rate': avg_sr,
+                'avg_discrimination': avg_disc,
+                'n_attempts': n_attempts_distinct,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
 def plot_question_analysis(results_df):
     """
     Create a scatter plot of question difficulty vs discrimination using matplotlib/seaborn.


### PR DESCRIPTION
## Summary
Follow-up to #7 (already merged): adds **assessment-level summary** (weighted avg success rate & discrimination per assessment, distinct attempts) and shows **section performance** only when **one** assessment is selected.

## Changes
- `assessment_level_summary_table()` in `utils_assessment_analysis.py`
- `5_[admin].py`: summary table at top; section charts gated on single-assessment filter

Made with [Cursor](https://cursor.com)